### PR TITLE
Replace hash function from object-hash by md5 from blueimp-md5

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "react": "<=16.8.0"
   },
   "dependencies": {
-    "object-hash": "^2.0.3"
+    "blueimp-md5": "^2.19.0"
   },
   "eslintConfig": {
     "env": {

--- a/src/useLocalStorage/index.js
+++ b/src/useLocalStorage/index.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import md5 from 'blueimp-md5'
 
-const hash = (object) => md5(JSON.stringify(object))
+export const hash = (object) => md5(JSON.stringify(object))
 
 const PREFIX = '__use_local_storage_state_hook'
 

--- a/src/useLocalStorage/index.js
+++ b/src/useLocalStorage/index.js
@@ -1,9 +1,11 @@
 import { useEffect, useState } from 'react'
-import hash from 'object-hash'
+import md5 from 'blueimp-md5'
+
+const hash = (object) => md5(JSON.stringify(object))
 
 const PREFIX = '__use_local_storage_state_hook'
 
-const getItem = key => {
+const getItem = (key) => {
   try {
     const value = window.localStorage.getItem(key)
     if (value) {

--- a/src/useLocalStorage/index.test.js
+++ b/src/useLocalStorage/index.test.js
@@ -1,6 +1,5 @@
 import { renderHook, act } from '@testing-library/react-hooks'
-import useLocalStorageState from '.'
-import hash from 'object-hash'
+import useLocalStorageState, { hash } from '.'
 
 beforeEach(() => {
   localStorage.clear()

--- a/yarn.lock
+++ b/yarn.lock
@@ -1688,6 +1688,11 @@ big.js@^5.2.2:
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
 
+blueimp-md5@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/blueimp-md5/-/blueimp-md5-2.19.0.tgz#b53feea5498dcb53dc6ec4b823adb84b729c4af0"
+  integrity sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==
+
 boolbase@^1.0.0, boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
@@ -4594,11 +4599,6 @@ object-copy@^0.1.0:
     copy-descriptor "^0.1.0"
     define-property "^0.2.5"
     kind-of "^3.0.3"
-
-object-hash@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.0.3.tgz#d12db044e03cd2ca3d77c0570d87225b02e1e6ea"
-  integrity sha512-JPKn0GMu+Fa3zt3Bmr66JhokJU5BaNBIh4ZeTlaCBzrBsOeXzwcKKAK1tbLiPKgvwmPXsDvvLHoWh5Bm7ofIYg==
 
 object-inspect@^1.7.0, object-inspect@^1.8.0:
   version "1.8.0"


### PR DESCRIPTION
This PR solves bundle size issues reported in #3 by replacing the heavy hash function from `object-hash` by the md5 function from `blueimp-md5`. We just need a hash function that generates a unique string for our objects so we know when the initial value changed or not, so using an md5 hash does the job.